### PR TITLE
docs: Expand the Introduction section in sidebar navigation

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -6,7 +6,28 @@ import { path } from '@vuepress/utils'
 import { SidebarOptions } from '@vuepress/theme-default'
 
 const sidebar: SidebarOptions = [
-  { text: 'Introduction', link: '/introduction' },
+  {
+    text: 'Introduction',
+    link: '/introduction',
+    children: [
+      {
+        text: 'Overview',
+        link: '/introduction#overview',
+      },
+      {
+        text: 'Introduction',
+        link: '/introduction#introduction',
+      },
+      {
+        text: 'Architecture',
+        link: '/introduction#architecture',
+      },
+      {
+        text: 'Join the Community',
+        link: '/introduction#join-the-community',
+      },
+    ]
+  },
   {
     text: 'Documents',
     prefix: 'documents',


### PR DESCRIPTION
### Before fix:

<img width="293" height="317" alt="截屏2026-03-09 16 22 57" src="https://github.com/user-attachments/assets/2ca68023-44fb-410a-9f02-55d323e8cdc2" />

### After fix:

<img width="305" height="456" alt="截屏2026-03-09 16 23 05" src="https://github.com/user-attachments/assets/22bfdf59-3a05-4f33-872b-d6a8845ffb43" />
