### PR TITLE
Add favicon to fix 404 error

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -61,6 +61,9 @@ const navbar: NavbarOptions = [
 
 export default defineUserConfig({
   base: '/',
+  head: [
+    ['link', { rel: 'icon', href: '/logo-mini.png' }]
+  ],
   theme: defaultTheme({
     logo: '/auron.svg',
     home: '/',


### PR DESCRIPTION
Configure logo-mini.png as the site favicon to prevent browser 
from requesting non-existent /favicon.ico and showing 404 errors.

Before & After :
<img width="571" height="80" alt="image" src="https://github.com/user-attachments/assets/160f7c3f-1fb5-463e-a53b-8973f8674277" />
